### PR TITLE
Architectures: fix RISC-V Wikipedia link

### DIFF
--- a/Architectures.md
+++ b/Architectures.md
@@ -256,7 +256,7 @@ Type|Macro
 ---|---
 Identification|`pyr`
 
-## [RISC-V](https://ru.wikipedia.org/wiki/RISC-V) ##
+## [RISC-V](https://en.wikipedia.org/wiki/RISC-V) ##
 
 Type|Macro|Description
 ---|---|---


### PR DESCRIPTION
Probably overlooked that fact that Wikipedia redirected me to its Russian counterpart