### PR TITLE
OperatingSystems: fix broken VxWorks table

### DIFF
--- a/OperatingSystems.md
+++ b/OperatingSystems.md
@@ -597,7 +597,7 @@ VMS|`__VMS_VER`
 ## [VxWorks](http://en.wikipedia.org/wiki/VxWorks) ##
 
 Type|Macro|Description
----|---|---|--
+---|---|---
 Identification|`__VXWORKS__`|Defined by GNU C and Diab (from ?)
 Identification|`__vxworks`|Defined by GNU C and Diab (from ?)
 Version|`_WRS_VXWORKS_MAJOR`|Version<br/><br/>Must be included from `<version.h>`


### PR DESCRIPTION
The VxWorks table doesn't render correctly due to a bad header. This commit fixes this.