### PR TITLE
Data models: add __fourbyteints__

### DIFF
--- a/DataModels.md
+++ b/DataModels.md
@@ -9,12 +9,19 @@ long | 32 | 32 | 64 | 32 | 64 | 64
 long long | | | 64 | 64 | 64 | 64
 pointer | 32 | 32 | 64 | 64 | 64 | 64
 
+## LP32 ##
+
+Macro | Description
+---|---
+`__fourbyteints__` = 0| Defined by MPW and Metrowerks on Motorola 68k targets when configured to use 16-bit int
+
 ## ILP32 ##
 
 Macro | Description
 ---|---
 `_ILP32` | Defined by HP aCC and Sun Studio
 `__ILP32__` | Defined by GNU C
+`__fourbyteints__` = 1| Defined by MPW and Metrowerks on Motorola 68k targets when configured to use 32-bit int
 
 ## LP64 ##
 


### PR DESCRIPTION
This can be found in the "C, C++, and Assembly Language Reference" document for CodeWarrior. MPW also defines this macro, but I was unable to find where it is documented.