### PR TITLE
add nvhpc by NVIDIA

### DIFF
--- a/Compilers.md
+++ b/Compilers.md
@@ -761,6 +761,12 @@ Type|Macro
 ---|---
 Identification|`__NWCC__`
 
+## [NVHPC](https://developer.nvidia.com/hpc-sdk)
+
+Type|Macro
+---|---
+Identification|`__NVCOMPILER`
+
 ## [Open64](http://en.wikipedia.org/wiki/Open64) ##
 
 Type|Macro|Format|Description


### PR DESCRIPTION
I just add the main macro for the nvidia compilers

doc: https://docs.nvidia.com/hpc-sdk/compilers/hpc-compilers-ref-guide/index.html#unique_557927916