### PR TITLE
fix links, add more references, and indent the source

### DIFF
--- a/DataModels.md
+++ b/DataModels.md
@@ -1,4 +1,4 @@
-## [Data Models](http://www.unix.org/whitepapers/64bit.html) ##
+## [Data Models](https://www.unix.org/whitepapers/64bit.html) ##
 
 Data type | LP32 | ILP32 | LP64 | LLP64 | ILP64 | SILP64
 ---|---|---|---|---|---|---

--- a/Endianness.md
+++ b/Endianness.md
@@ -13,7 +13,7 @@ Some compilers or system headers provide macros to determine endianness, but the
 
 * Avoid endianness whenever possible.
 * Use endian-neutral code (see example below.)
-* Use existing conversion functions, such as `htons()` to convert between network byte-order and the native byte-order of the processor.
+* Use existing conversion functions, such as `htons()` and `htonl()` to convert from network to host byte-order and `bswap_16()`, `bswap_32()`, and `bswap_64()` to covert to the native byte-order of the processor.
 * Detect endianness at run-time (see example below.)
 * Detect endianness at configuration-time, for example by using the Autoconf `AC_C_BIGENDIAN` feature. While this method works well when the same platform is used to build and host (execute) the package, you must take care when using autoconf in a cross-development environment, as the endianness of the build and host platforms may not be identical.
 * Detect endianness at compile-time. There are several options:
@@ -31,27 +31,27 @@ When endianness is needed for (de)marshalling binary data, you can write endian-
 /* Type */ unsigned int
 endian_native_unsigned_int(/* Type */ unsigned int net_number)
 {
-/* Type */ unsigned int result = 0;
-int i;
+	/* Type */ unsigned int result = 0;
+	int i;
 
-for (i = 0; i < (int)sizeof(result); i++) {
-result <<= CHAR_BIT;
-result += (((unsigned char *)&net_number)[i] & UCHAR_MAX);
-}
-return result;
+	for (i = 0; i < (int)sizeof(result); i++) {
+		result <<= CHAR_BIT;
+		result += (((unsigned char *)&net_number)[i] & UCHAR_MAX);
+	}
+	return result;
 }
 
 /* Type */ unsigned int
 endian_net_unsigned_int(/* Type */ unsigned int native_number)
 {
-/* Type */ unsigned int result = 0;
-int i;
+	/* Type */ unsigned int result = 0;
+	int i;
 
-for (i = (int)sizeof(result) - 1; i >= 0; i--) {
-((unsigned char *)&result)[i] = native_number & UCHAR_MAX;
-native_number >>= CHAR_BIT;
-}
-return result;
+	for (i = (int)sizeof(result) - 1; i >= 0; i--) {
+		((unsigned char *)&result)[i] = native_number & UCHAR_MAX;
+		native_number >>= CHAR_BIT;
+	}
+	return result;
 }
 ```
 
@@ -61,34 +61,32 @@ return result;
 #include <stdint.h>
 
 enum {
-ENDIAN_UNKNOWN,
-ENDIAN_BIG,
-ENDIAN_LITTLE,
-ENDIAN_BIG_WORD, /* Middle-endian, Honeywell 316 style */
-ENDIAN_LITTLE_WORD /* Middle-endian, PDP-11 style */
+	ENDIAN_UNKNOWN,
+	ENDIAN_BIG,
+	ENDIAN_LITTLE,
+	ENDIAN_BIG_WORD, /* Middle-endian, Honeywell 316 style */
+	ENDIAN_LITTLE_WORD /* Middle-endian, PDP-11 style */
 };
 
 int endianness(void)
 {
-union
-{
-uint32_t value;
-uint8_t data[sizeof(uint32_t)];
-} number;
+	union {
+		uint32_t value;
+		uint8_t data[sizeof(uint32_t)];
+	} number;
 
-number.data[0] = 0x00;
-number.data[1] = 0x01;
-number.data[2] = 0x02;
-number.data[3] = 0x03;
+	number.data[0] = 0x00;
+	number.data[1] = 0x01;
+	number.data[2] = 0x02;
+	number.data[3] = 0x03;
 
-switch (number.value)
-{
-case UINT32_C(0x00010203): return ENDIAN_BIG;
-case UINT32_C(0x03020100): return ENDIAN_LITTLE;
-case UINT32_C(0x02030001): return ENDIAN_BIG_WORD;
-case UINT32_C(0x01000302): return ENDIAN_LITTLE_WORD;
-default: return ENDIAN_UNKNOWN;
-}
+	switch (number.value) {
+	case UINT32_C(0x00010203): return ENDIAN_BIG;
+	case UINT32_C(0x03020100): return ENDIAN_LITTLE;
+	case UINT32_C(0x02030001): return ENDIAN_BIG_WORD;
+	case UINT32_C(0x01000302): return ENDIAN_LITTLE_WORD;
+	default: return ENDIAN_UNKNOWN;
+	}
 }
 ```
 

--- a/Endianness.md
+++ b/Endianness.md
@@ -13,7 +13,7 @@ Some compilers or system headers provide macros to determine endianness, but the
 
 * Avoid endianness whenever possible.
 * Use endian-neutral code (see example below.)
-* Use existing conversion functions, such as `htons()` and `htonl()` to convert from network to host byte-order and `bswap_16()`, `bswap_32()`, and `bswap_64()` to covert to the native byte-order of the processor.
+* Use existing conversion functions to convert between network byte-order and native byte-order of the processor.
 * Detect endianness at run-time (see example below.)
 * Detect endianness at configuration-time, for example by using the Autoconf `AC_C_BIGENDIAN` feature. While this method works well when the same platform is used to build and host (execute) the package, you must take care when using autoconf in a cross-development environment, as the endianness of the build and host platforms may not be identical.
 * Detect endianness at compile-time. There are several options:

--- a/Standards.md
+++ b/Standards.md
@@ -6,18 +6,18 @@ Language standards requires the existence of pre-defined macros.
 
 Name | Macro | Standard
 ---|---|---
-C89|`__STDC__`|ANSI X3.159-1989
-C90|`__STDC__`|ISO/IEC 9899:1990
+[C89](https://en.wikipedia.org/wiki/ANSI_C#C89)|`__STDC__`|ANSI X3.159-1989
+[C90](https://en.wikipedia.org/wiki/ANSI_C#C90)|`__STDC__`|ISO/IEC 9899:1990
 C94|`__STDC_VERSION__` = 199409L|ISO/IEC 9899-1:1994
-[C99](http://www.open-std.org/jtc1/sc22/wg14/)|`__STDC_VERSION__` = 199901L|ISO/IEC 9899:1999
-[C11](http://en.wikipedia.org/wiki/C11_%28C_standard_revision%29)|`__STDC_VERSION__` = 201112L|ISO/IEC 9899:2011
-[C18](https://en.wikipedia.org/wiki/C18_%28C_standard_revision%29)|`__STDC_VERSION__` = 201710L|ISO/IEC 9899:2018
-[C++98](http://www.open-std.org/jtc1/sc22/wg21/)|`__cplusplus` = 199711L|ISO/IEC 14882:1998
-[C++11](http://en.wikipedia.org/wiki/C%2B%2B11)|`__cplusplus` = 201103L|ISO/IEC 14882:2011
-[C++14](http://en.wikipedia.org/wiki/C%2B%2B14)|`__cplusplus` = 201402L|ISO/IEC 14882:2014
-[C++17](http://en.wikipedia.org/wiki/C%2B%2B17)|`__cplusplus` = 201703L|ISO/IEC 14882:2017
-[C++/CLI](http://www.ecma-international.org/publications/standards/Ecma-372.htm)|`__cplusplus_cli` = 200406L|ECMA-372
-[DSP-C](http://www.dsp-c.org)| |ISO/IEC JTC1/SC22 WG14/N854
+[C99](https://en.wikipedia.org/wiki/C99)|`__STDC_VERSION__` = 199901L|ISO/IEC 9899:1999
+[C11](https://en.wikipedia.org/wiki/C11_%28C_standard_revision%29)|`__STDC_VERSION__` = 201112L|ISO/IEC 9899:2011
+[C17](https://en.wikipedia.org/wiki/C18_%28C_standard_revision%29)|`__STDC_VERSION__` = 201710L|ISO/IEC 9899:2018
+[C++98](https://www.open-std.org/jtc1/sc22/wg21/)|`__cplusplus` = 199711L|ISO/IEC 14882:1998
+[C++11](https://en.wikipedia.org/wiki/C%2B%2B11)|`__cplusplus` = 201103L|ISO/IEC 14882:2011
+[C++14](https://en.wikipedia.org/wiki/C%2B%2B14)|`__cplusplus` = 201402L|ISO/IEC 14882:2014
+[C++17](https://en.wikipedia.org/wiki/C%2B%2B17)|`__cplusplus` = 201703L|ISO/IEC 14882:2017
+[C++/CLI](https://web.archive.org/web/20160529152346/http://www.ecma-international.org/publications/standards/Ecma-372.htm)|`__cplusplus_cli` = 200406L|ECMA-372
+[DSP-C](https://web.archive.org/web/20070220061023/http://www.dsp-c.org/)| |ISO/IEC JTC1/SC22 WG14/N854
 [EC++](http://www.caravan.net/ec2plus/)|`__embedded_cplusplus`|Embedded C++
 
 ##### Example: C Standards #####
@@ -59,8 +59,8 @@ Unix standards require the existence macros in the `<unistd.h>` header file.
 
 Name | Macro | Standard
 ---|---|---
-POSIX.1-1988|`_POSIX_VERSION` = 198808L|
-POSIX.1-1990|`_POSIX_VERSION` = 199009L|ISO/IEC 9945-1:1990
+[POSIX.1-1988](https://nvlpubs.nist.gov/nistpubs/Legacy/FIPS/fipspub151-1.pdf)|`_POSIX_VERSION` = 198808L|
+[POSIX.1-1990](https://nvlpubs.nist.gov/nistpubs/Legacy/FIPS/fipspub151-2.pdf)|`_POSIX_VERSION` = 199009L|ISO/IEC 9945-1:1990
 POSIX.2|`_POSIX2_C_VERSION` = 199209L|ISO/IEC 9945-2:1993
 POSIX.1b-1993|`_POSIX_VERSION` = 199309L|IEEE 1003.1b-1993
 POSIX.1-1996|`_POSIX_VERSION` = 199506L|IEEE 1003.1-1996
@@ -69,9 +69,9 @@ POSIX.1-2001|`_POSIX_VERSION` = 200112L|IEEE 1003.1-2001
 XPG3|`_XOPEN_VERSION` = 3|X/Open Portability Guide 3 (1989)
 XPG4|`_XOPEN_VERSION` = 4|X/Open Portability Guide 4 (1992)
 SUS|`_XOPEN_VERSION` = 4 `&&` `_XOPEN_UNIX`|X/Open Single UNIX Specification (UNIX95)
-[SUSv2](http://www.opengroup.org/onlinepubs/7908799/toc.htm)|`_XOPEN_VERSION` = 500|X/Open Single UNIX Specification, Version 2 (UNIX98)
-[SUSv3](http://www.opengroup.org/onlinepubs/007904975/nfindex.html)|`_XOPEN_VERSION` = 600|Open Group Single UNIX Specification, Version 3 (UNIX03)
-[SUSv4](http://pubs.opengroup.org/onlinepubs/9699919799/)|`_XOPEN_VERSION` = 700|Open Group Single UNIX Specification, Version 4
+[SUSv2](https://pubs.opengroup.org/onlinepubs/7908799/toc.htm)|`_XOPEN_VERSION` = 500|X/Open Single UNIX Specification, Version 2 (UNIX98)
+[SUSv3](https://pubs.opengroup.org/onlinepubs/007904975/nfindex.html)|`_XOPEN_VERSION` = 600|Open Group Single UNIX Specification, Version 3 (UNIX03)
+[SUSv4](https://pubs.opengroup.org/onlinepubs/9699919799/)|`_XOPEN_VERSION` = 700|Open Group Single UNIX Specification, Version 4
 LSB|`__LSB_VERSION__` = VR|Linux Standards Base<br/><br/>V = Version<br/>R = Revision
 
 ##### Example: Unix Standards #####


### PR DESCRIPTION
Standards.md:
1. Add C89, and C90 references, and point them to Wikipedia.

2. C99 and C11, use HTTPS instead of the HTTP URL.

3. Use C17 term, and not C18. Although both are just valid, the widely used term is C17, and C18 can be confusing (for those who don't know that both are the same).

4. C17, C++{98,11,14,17}, use HTTPS.

5. The original document for C++/CLI is no longer available, and I can only able to find an archived version (including the PDF) on the Internet Archive. So replace the original URL with the archived one.

6. DSP-C is also no longer available. Fortunately, there's an archived version of the page, completely functional. Replace the original URL with the archived one.

7. Add PDFs for POSIX.1-1988 and POSIX.1-1990.

8. SUSv{2,3,4} use HTTPS.

Endianness.md:
1. CPU byte order convertion shouldn't be done using htons() function. htons() is defined and used to convert host to network byte order, and if the host and network server both are consists different endians, this will not work, as if the host is big-endian, htons() just returns the input value and no convertion is performed. Also, considering, htons() only accept unsigned short, it also need to conver htonl() (unsigned int).

2. Indent the example code.

DataModels.md:
Use HTTPS, as HTTP request is unreachable (blocked by their firewall).