### PR TITLE
Update Native Client definitions

### DIFF
--- a/Architectures.md
+++ b/Architectures.md
@@ -246,6 +246,12 @@ R4400|`_MIPS_ISA_MIPS3`| |3|`__MIPS_ISA3__`
 R8000|`_MIPS_ISA_MIPS4`| |4|`__MIPS_ISA4__`
 R10000|`_MIPS_ISA_MIPS4`| |4|`__MIPS_ISA4__`
 
+## [Native Client](https://en.wikipedia.org/wiki/Google_Native_Client) ##
+
+Type|Macro|Description
+---|---|---
+Identification|`__native_client__`|Defined by NaCl GCC, PNaCl Clang and Saigo
+
 ## [NEC SX-Aurora TSUBASA](https://en.wikipedia.org/wiki/NEC_SX-Aurora_TSUBASA) ##
 
 Type|Macro|Description
@@ -256,9 +262,9 @@ Identification|`__NEC__`|Defined by NEC C/C++ Compiler and Clang
 
 ## [PNaCl](https://en.wikipedia.org/wiki/Google_Native_Client) ##
 
-Type|Macro
----|---
-Identification|`__pnacl__`
+Type|Macro|Description
+---|---|---
+Identification|`__pnacl__`|Defined by PNaCl Clang
 
 ## [PowerPC](http://en.wikipedia.org/wiki/PowerPC) ##
 

--- a/Compilers.md
+++ b/Compilers.md
@@ -893,6 +893,12 @@ Renesas C/C++|`__HITACHI_VERSION__`|`__RENESAS_VERSION__`
 8.0|0x8000|0x8000
 1.00.00| |0x01000000
 
+## [Saigo](https://chromium.googlesource.com/native_client/nacl-llvm-project-v10) ##
+
+Type|Macro
+---|---
+Identification|`__saigo__`
+
 ## [SAS/C](http://www.sas.com/products/sasc/) ##
 
 Type|Macro|Format|Description


### PR DESCRIPTION
Hi, this updates the Native Client definitions.

To understand it better, here is some generic knowledge about the Native Client ecosystem.

The various toolchains produced different kind of binaries:

- `nexe`: architecture-dependent executable.
- `pexe`: architecture-independent executable, meant to be translated to `nexe` before execution using a special tool.

A PNaCl compiler produces `pexe` executable, while an NaCl compiler produces `nexe` executable.

While the `pexe` format can be seen as a kind of platform, in practice there is no runner for it: a `pexe` should be translated to `nexe` to be executed by the NaCl loader.

There has been at least 5 Native Client compilers:

- NaCl GCC https://chromium.googlesource.com/native_client/nacl-gcc
  * Part of the latest public SDK publied by Google before the deprecation of Native Client;
  * The only compiler capable of building some components of the NaCl libc. Compiles to `nexe`;
  * Compiler binaries are named like `x86_64-nacl-gcc`.
- PNaCl GCC https://chromium.googlesource.com/native_client/pnacl-gcc
  * Likely some proof of concept before switching to Clangl. The name suggests it was meant to produce `pexe`;
  * I never seen a binary of it being distributed, 13 years later it doesn't build anymore;
  * I was not able to test it, I guess we can ignore that.
- PNaCl Clang https://chromium.googlesource.com/native_client/pnacl-llvm
  * Part of the latest public SDK publied by Google before the deprecation of Native Client;
  * Compiles to `pexe`;
  * Compiler binaries are named like `pnacl-clang`.
- NaCl Clang https://chromium.googlesource.com/native_client/pnacl-llvm
  * Part of the latest public SDK publied by Google before the deprecation of Native Client;
  * Part of the PNaCl Clang project;
  * Compiles to `nexe`;
  * Compiler binaries are named like `x86_64-nacl-clang`.
- Saigo https://chromium.googlesource.com/native_client/nacl-llvm-project-v10
  * Current compiler maintained by Google, frequently rebased on latest Clang (currently Clang 19);
  * Linux builds provided by Google through their CDN;
  * Compiles to `nexe`.
  * Compiler binaries are named like `x86_64-nacl-clang`.

The PNaCl Clang compiler and the NaCl Clang compiler share the same repository and are both part of the PNaCl Clang project, I listed them separately because the different binaries produce different defines.

Here is some knowledge I gathered:

Among all the compilers I tested (all but PNaCl GCC), only PNaCl Clang sets the `__pnacl__` definition.

All the compilers I tested (all but PNaCl GCC) set the `__native_client__` definition, so this is a better one to detect Native Client than `__pnacl__`.

I have found some `__native_client__` and some `__pnacl__` usage in some header files in the PNaCl GCC source directory. So maybe the `__pnacl__` is usable to detect a pexe compiler.

According to [this comment](https://stackoverflow.com/a/26659103), 10 years ago PNaCl Clang was built on Ubuntu 12.04 and developed on Ubuntu 14.04, so I guess the 13 years old PNaCl GCC requires an environment as old as that to be built, if not older. It's very unlikely the PNaCl GCC can be faced in the wild.

In real life, finding the `__pnacl__` definition means the PNaCl Clang compiler is used.

The Saigo compilers sets the `__saigo__` definition.

Among the users of Native Client today we can list:

- Google (assumed to still be using it if they funded the development of a new toolchain and are still funding the maintenance of it, but I don't know what they do with it, maybe some chrome apps…).
- The [Dæmon game engine](https://github.com/DaemonEngine/Daemon) powering the [Unvanquished](https://unvanquished.net/) game, using Native Client as the sandbox to run downloaded custom mods. We are migrating from PNaCl to Saigo, and I thought I could share some knowledge. 😉️

Summary:

- NaCl GCC
  * `__native_client__`
- PNaCl GCC
  * supposedly `__native_client__` (unverified)
  * supposedly `__pnacl__` (unverified)
- PNaCl Clang
  * `__native_client__`
  * `__pnacl__`
- NaCl Clang
  * `__native_client__`
- Saigo
  * `__native_client__`
  * `__saigo__`
  
While it is true facing a `__pnacl__` definition means this a Native Client architecture being targeted, not all NaCl compilers set it, it is better to use `__native_client__` instead.

So…

- I've kept the “PNaCl” architecture even if it doesn't sound that useful.
- I've added the “Native Client” architecture which is much more useful.
- I've added the “Saigo” compiler.
- I haven't made a difference between the PNaCl Clang and the NaCl Clang in the description, as they're just different binaries from the same source. It is still true that binaries from the PNaCl Clang project producing `nexe` are defining `__native_client__`.